### PR TITLE
fix github link link

### DIFF
--- a/index.html
+++ b/index.html
@@ -66,7 +66,7 @@
         <li><a id="nav_bing"></a></li>
         <li><a id="nav_osm"></a></li>
         <li><a id="nav_discuss" href="https://groups.google.com/forum/#!forum/open-location-code"></a></li>
-        <li><a id="nav_github" href="//github.org/google/open-location-code/"></a></li>
+        <li><a id="nav_github" href="//github.com/google/open-location-code/"></a></li>
         <li><a class="nav_dismiss"></a></li>
     </nav>
     <nav id="language-menu" class="navdrawer-container">


### PR DESCRIPTION
This typo was pointed out at google/open-location-code#33
